### PR TITLE
Minor HTML parsing update

### DIFF
--- a/src/main/java/com/syndicapp/scraper/aib/RegistrationNumberPage.java
+++ b/src/main/java/com/syndicapp/scraper/aib/RegistrationNumberPage.java
@@ -54,7 +54,7 @@ public class RegistrationNumberPage extends FSSUserAgent
         log.debug(page);
         outputParams.put("page", thisPage + "\n" + page);
         
-        p = Pattern.compile("<label class=\"alignc\" for=\"digit\\d\"><strong>Digit\\s*(\\d)</strong>\\s*</label>");
+        p = Pattern.compile("<label class=\"alignc\" for=\"digit\\dText\"><strong>Digit\\s*(\\d)</strong>\\s*</label>");
         m = p.matcher(page);
         for(int d = 1; m.find(); d++) {
             outputParams.put((new StringBuilder()).append("digit").append(d).toString(), m.group(1));


### PR DESCRIPTION
BASE_URL/v2/login/registration returns null values for each of the
requested PAC digits.  This is due to a minor change to the page HTML.

This minor fix updates the scraper to account for this change.
